### PR TITLE
Add Gemini prompt to Create Form Button and verify response

### DIFF
--- a/app/edit-form/[formId]/page.jsx
+++ b/app/edit-form/[formId]/page.jsx
@@ -1,0 +1,9 @@
+import React from 'react'
+
+function EditForm() {
+  return (
+    <div>EditForm</div>
+  )
+}
+
+export default EditForm

--- a/configs/aiModel.js
+++ b/configs/aiModel.js
@@ -16,7 +16,7 @@ const generationConfig = {
     topP: 0.95,
     topK: 64,
     maxOutputTokens: 8192,
-    responseMimeType: "text/plain",
+    responseMimeType: "application/json",
 };
 
 const safetySettings = [


### PR DESCRIPTION
### Description

This pull request introduces a new CreateForm component for the dashboard, allowing users to create forms using AI-generated JSON templates. It also includes necessary backend schema and configuration changes, as well as an edit form page.

### Changes Made To:

- New Files:

    app/edit-form/[formId]/page.jsx

- Modified Files:

    app/dashboard/page.jsx
    app/dashboard/_components/CreateForm.jsx
    configs/aiModel.js
    package-lock.json
    package.json

### Dependencies

    [@radix-ui/react-dialog](https://www.npmjs.com/package/@radix-ui/react-dialog) ^1.0.5
    [shadcn/ui](https://shadcn.dev/)
    [@google/generative-ai](https://www.npmjs.com/package/@google/generative-ai) ^0.12.0
    [moment](https://www.npmjs.com/package/moment) ^2.30.1
    [lucide-react](https://www.npmjs.com/package/lucide-react) ^0.13.0

### Testing

- Confirmed that the CreateForm dialog opens and closes correctly.
- Verified that the textarea captures user input and logs it on form creation.
- Confirmed AI integration generates form structure based on user input.
     - Resolved issue with ```json and ``` being added to beginning and end of prompt. **Had to change `responseMimeType: "text/plain"` to `responseMimeType: "application/json"` in aiModel.js** 
- Verified form data is inserted into the database correctly and redirects to the edit form page.
- Checked loading state and button spinner during form creation.

Future Work

N/A